### PR TITLE
fix: Ensure final content is always the expected text

### DIFF
--- a/src/modes/scramble.js
+++ b/src/modes/scramble.js
@@ -71,6 +71,8 @@ export const mode = async (elements, options) => {
 					break
 				}
 			}
+			
+			currentNode.innerHTML = text
 		})
 	})
 	options.dispatch('done')


### PR DESCRIPTION
When using scramble mode, if you tab away AFTER the unscramble has started playing but before it finishes, then remain on that other tab until after the `Date.now() - startingTime < timeout` (`scramble.js:40`) timeout completes, the text will remain in a scrambled state, despite thinking it's complete. The addition of the line below simply ensures that&mdash;after the timeout&mdash;the text is set back to what it's expected to be.

Observed on Chromium 97.0.4692.71